### PR TITLE
fix: add experiment check for user storage test

### DIFF
--- a/src/test-cases/index.json
+++ b/src/test-cases/index.json
@@ -553,7 +553,8 @@
         "storageData": {
           "rolloutKey": "feature1_rolloutRule1",
           "rolloutVariationId": 1,
-          "experimentVariationId": 1
+          "experimentVariationId": 1,
+          "experimentKey": "feature1_testingRule1"
         }
       }
     },


### PR DESCRIPTION
experimentKey was missing in json file for getFlag with storage test cases.